### PR TITLE
Add myself to gem authors

### DIFF
--- a/r18n-core.gemspec
+++ b/r18n-core.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |s|
   s.files = Dir['lib/**/*.rb', 'base/**/*.y{a,}ml', 'README.md', 'LICENSE', 'ChangeLog.md']
   s.extra_rdoc_files = ['README.md', 'LICENSE']
 
-  s.author   = 'Andrey Sitnik'
-  s.email    = 'andrey@sitnik.ru'
+  s.authors  = ['Andrey Sitnik', 'Alexander Popov']
+  s.email    = ['andrey@sitnik.ru', 'alex.wayfer@gmail.com']
   s.homepage = 'https://github.com/r18n/r18n'
   s.license  = 'LGPL-3.0'
 


### PR DESCRIPTION
I'm very doubting in it. I'm contributor and kind of maintainer, yes,
but I've done not too much impact in comparison with the original author.

But I'd like to leave "actual" contact info.
It's not necessary to do it in the gem specs,
but it can be uselful there for somebody.

@ai, what do you think?