### PR TITLE
Add an Sv locale

### DIFF
--- a/lib/r18n-core/locales/sv-se.rb
+++ b/lib/r18n-core/locales/sv-se.rb
@@ -18,7 +18,7 @@ module R18n
         month_abbrs: %w[jan feb mar apr maj jun jul aug okt nov dec],
 
         date_format: '%Y-%m-%d',
-        full_format: '%-d %B %Y',
+        full_format: '%-d %B',
 
         number_decimal: ',',
         number_group: '.'

--- a/lib/r18n-core/locales/sv-se.rb
+++ b/lib/r18n-core/locales/sv-se.rb
@@ -3,26 +3,7 @@
 module R18n
   module Locales
     # Swedish (Sweden) locale
-    class SvSE < Locale
-      set(
-        title: 'Svenska',
-        sublocales: %w[sv en],
-
-        wday_names: %w[söndag måndag tisdag onsdag torsdag fredag lördag],
-        wday_abbrs: %w[sön mån tis ons tor fre lör],
-
-        month_names: %w[
-          januari februari mars april maj juni juli augusti september oktober
-          november december
-        ],
-        month_abbrs: %w[jan feb mar apr maj jun jul aug okt nov dec],
-
-        date_format: '%Y-%m-%d',
-        full_format: '%-d %B',
-
-        number_decimal: ',',
-        number_group: '.'
-      )
+    class SvSE < Sv
     end
   end
 end

--- a/lib/r18n-core/locales/sv-se.rb
+++ b/lib/r18n-core/locales/sv-se.rb
@@ -4,6 +4,10 @@ module R18n
   module Locales
     # Swedish (Sweden) locale
     class SvSE < Sv
+      set(
+        title: 'Svenska (Sverige)',
+        sublocales: %w[sv]
+      )
     end
   end
 end

--- a/lib/r18n-core/locales/sv.rb
+++ b/lib/r18n-core/locales/sv.rb
@@ -3,7 +3,26 @@
 module R18n
   module Locales
     # Swedish locale
-    class Sv < SvSE
+    class Sv < Locale
+      set(
+        title: 'Svenska',
+        sublocales: %w[sv en],
+
+        wday_names: %w[söndag måndag tisdag onsdag torsdag fredag lördag],
+        wday_abbrs: %w[sön mån tis ons tor fre lör],
+
+        month_names: %w[
+          januari februari mars april maj juni juli augusti september oktober
+          november december
+        ],
+        month_abbrs: %w[jan feb mar apr maj jun jul aug okt nov dec],
+
+        date_format: '%Y-%m-%d',
+        full_format: '%-d %B',
+
+        number_decimal: ',',
+        number_group: '.'
+      )
     end
   end
 end

--- a/lib/r18n-core/locales/sv.rb
+++ b/lib/r18n-core/locales/sv.rb
@@ -6,7 +6,7 @@ module R18n
     class Sv < Locale
       set(
         title: 'Svenska',
-        sublocales: %w[sv],
+        sublocales: %w[sv-SE],
 
         wday_names: %w[söndag måndag tisdag onsdag torsdag fredag lördag],
         wday_abbrs: %w[sön mån tis ons tor fre lör],

--- a/lib/r18n-core/locales/sv.rb
+++ b/lib/r18n-core/locales/sv.rb
@@ -6,7 +6,7 @@ module R18n
     class Sv < Locale
       set(
         title: 'Svenska',
-        sublocales: %w[sv en],
+        sublocales: %w[sv],
 
         wday_names: %w[söndag måndag tisdag onsdag torsdag fredag lördag],
         wday_abbrs: %w[sön mån tis ons tor fre lör],

--- a/lib/r18n-core/locales/sv.rb
+++ b/lib/r18n-core/locales/sv.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module R18n
+  module Locales
+    # Swedish locale
+    class Sv < SvSE
+    end
+  end
+end

--- a/spec/locales/sv-se_spec.rb
+++ b/spec/locales/sv-se_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+describe R18n::Locales::SvSE do
+  it 'formats Swedish (Sweden) date' do
+    en = R18n::I18n.new('sv-se')
+    expect(en.l(Date.parse('2009-05-01'), :full)).to eq('1 maj 2009')
+    expect(en.l(Date.parse('2009-05-01'), :full, year: false)).to eq('1 maj')
+  end
+end

--- a/spec/locales/sv-se_spec.rb
+++ b/spec/locales/sv-se_spec.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 describe R18n::Locales::SvSE do
+  it 'has correct title' do
+    sv_se = R18n.locale('sv-se')
+    expect(sv_se.title).to eq('Svenska (Sverige)')
+  end
+
   it 'formats Swedish (Sweden) date' do
     sv_se = R18n::I18n.new('sv-se')
     expect(sv_se.l(Date.parse('2009-05-01'), :full)).to eq('1 maj 2009')

--- a/spec/locales/sv-se_spec.rb
+++ b/spec/locales/sv-se_spec.rb
@@ -2,8 +2,8 @@
 
 describe R18n::Locales::SvSE do
   it 'formats Swedish (Sweden) date' do
-    en = R18n::I18n.new('sv-se')
-    expect(en.l(Date.parse('2009-05-01'), :full)).to eq('1 maj 2009')
-    expect(en.l(Date.parse('2009-05-01'), :full, year: false)).to eq('1 maj')
+    sv_se = R18n::I18n.new('sv-se')
+    expect(sv_se.l(Date.parse('2009-05-01'), :full)).to eq('1 maj 2009')
+    expect(sv_se.l(Date.parse('2009-05-01'), :full, year: false)).to eq('1 maj')
   end
 end

--- a/spec/locales/sv_spec.rb
+++ b/spec/locales/sv_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+describe R18n::Locales::Sv do
+  it 'formats Swedish date' do
+    en = R18n::I18n.new('sv')
+    expect(en.l(Date.parse('2009-05-01'), :full)).to eq('1 maj 2009')
+    expect(en.l(Date.parse('2009-05-01'), :full, year: false)).to eq('1 maj')
+  end
+end

--- a/spec/locales/sv_spec.rb
+++ b/spec/locales/sv_spec.rb
@@ -2,8 +2,8 @@
 
 describe R18n::Locales::Sv do
   it 'formats Swedish date' do
-    en = R18n::I18n.new('sv')
-    expect(en.l(Date.parse('2009-05-01'), :full)).to eq('1 maj 2009')
-    expect(en.l(Date.parse('2009-05-01'), :full, year: false)).to eq('1 maj')
+    sv = R18n::I18n.new('sv')
+    expect(sv.l(Date.parse('2009-05-01'), :full)).to eq('1 maj 2009')
+    expect(sv.l(Date.parse('2009-05-01'), :full, year: false)).to eq('1 maj')
   end
 end

--- a/spec/locales/sv_spec.rb
+++ b/spec/locales/sv_spec.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 describe R18n::Locales::Sv do
+  it 'has correct title' do
+    sv = R18n.locale('sv')
+    expect(sv.title).to eq('Svenska')
+  end
+
   it 'formats Swedish date' do
     sv = R18n::I18n.new('sv')
     expect(sv.l(Date.parse('2009-05-01'), :full)).to eq('1 maj 2009')


### PR DESCRIPTION
The Sv locale is the same as the SvSE one, the translations of the words added here do not differ in other Swedish-speaking regions.