### PR TITLE
Remove unused require ostruct, to avoid a warning

### DIFF
--- a/lib/r18n-core/filters.rb
+++ b/lib/r18n-core/filters.rb
@@ -17,8 +17,6 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-require 'ostruct'
-
 # R18n filters definition
 module R18n
   # Filter is a way, to process translations: escape HTML entries, convert from


### PR DESCRIPTION
cf65389c added this, and at that time, OpenStruct was used in the class. Now it is no longer.

This avoids a Ruby warning about ostruct not being available as a built-in after Ruby 3.5.0.

Fixes #108 