### PR TITLE
Update Ruby (minimal) required version

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -43,8 +43,6 @@ rubocop_task:
 test_task:
   container:
     matrix:
-      image: ruby:3.0
-      image: ruby:3.1
       image: ruby:3.2
       image: ruby:3.3
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ require:
   # - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.2
   NewCops: enable
   Exclude:
     <% `git status --ignored --porcelain`.lines.grep(/^!! /).each do |path| %>

--- a/lib/r18n-core/filter_list.rb
+++ b/lib/r18n-core/filter_list.rb
@@ -23,7 +23,7 @@ module R18n
   class FilterList
     # Process `value` by filters in `enabled`.
     def process(filters_type, type, value, locale, path, params)
-      config = { locale: locale, path: path }
+      config = { locale:, path: }
 
       enabled(filters_type, type).each do |filter|
         value = filter.call(value, config, *params)

--- a/lib/r18n-core/filters.rb
+++ b/lib/r18n-core/filters.rb
@@ -193,7 +193,7 @@ module R18n
       end
 
       # Return filters, which be added inside `block`.
-      def listen(&_block)
+      def listen(&)
         filters = []
         @new_filter_listener = proc { |i| filters << i }
         yield

--- a/lib/r18n-core/i18n.rb
+++ b/lib/r18n-core/i18n.rb
@@ -262,8 +262,8 @@ module R18n
     #   i18n.l Time.now.to_date #=> "07/01/09"
     #   i18n.l Time.now, :human #=> "now"
     #   i18n.l Time.now, :full  #=> "Jule 1st, 2009 12:59"
-    def localize(object, format = nil, **kwargs)
-      locale.localize(object, format, i18n: self, **kwargs)
+    def localize(object, format = nil, **)
+      locale.localize(object, format, i18n: self, **)
     end
     alias l localize
 

--- a/lib/r18n-core/locale.rb
+++ b/lib/r18n-core/locale.rb
@@ -177,7 +177,7 @@ module R18n
     # `:full` ("01 Jule, 2009"), `:human` ("yesterday"),
     # `:standard` ("07/01/09") or `:month` for standalone month
     # name. Default format is `:standard`.
-    def localize(obj, format = nil, *args, **kwargs)
+    def localize(obj, format = nil, *, **kwargs)
       case obj
       when Integer
         format_integer(obj)
@@ -196,14 +196,14 @@ module R18n
           raise ArgumentError, "Unknown time formatter #{format}"
         end
 
-        send format_method_name, obj, *args, **kwargs
+        send format_method_name, obj, *, **kwargs
       else
         format_method_name =
           "format_#{Utils.underscore(obj.class.name).tr('/', '_')}_#{format}"
 
         return obj.to_s unless respond_to? format_method_name
 
-        send format_method_name, obj, *args, **kwargs
+        send format_method_name, obj, *, **kwargs
       end
     end
 
@@ -266,7 +266,7 @@ module R18n
       minutes = time.is_a?(DateTime) ? diff * 24 * 60.0 : diff / 60.0
       diff = minutes.abs
       if (diff > 24 * 60) || (time.mday != now.mday && diff > 12 * 24)
-        format_time(format_date_human(time.to_date, now: now.to_date, i18n: i18n), time)
+        format_time(format_date_human(time.to_date, now: now.to_date, i18n:), time)
       elsif minutes > -1 && minutes < 1
         i18n.human_time.now
       elsif minutes >= 60
@@ -281,14 +281,14 @@ module R18n
     end
 
     # Format `time` in compact form. For example, "12/31/09 12:59".
-    def format_time_standard(time, *args, **kwargs)
-      format_time(format_date_standard(time), time, *args, **kwargs)
+    def format_time_standard(time, *, **)
+      format_time(format_date_standard(time), time, *, **)
     end
 
     # Format `time` in most official form. For example, "December 31st, 2009
     # 12:59". For special cases you can replace it in locale's class.
-    def format_time_full(time, **kwargs)
-      format_time(format_date_full(time, **kwargs), time, **kwargs)
+    def format_time_full(time, **)
+      format_time(format_date_full(time, **), time, **)
     end
 
     # Format `date` in human usable form. For example "5 days ago" or "yesterday".

--- a/lib/r18n-core/locales/fr.rb
+++ b/lib/r18n-core/locales/fr.rb
@@ -27,7 +27,7 @@ module R18n
       )
 
       def format_date_full(date, year: true, **_kwargs)
-        full = super(date, year: year)
+        full = super(date, year:)
         if full[0..1] == '1 '
           "1er#{full[1..]}"
         else

--- a/lib/r18n-core/locales/it.rb
+++ b/lib/r18n-core/locales/it.rb
@@ -25,7 +25,7 @@ module R18n
       )
 
       def format_date_full(date, year: true, **_kwargs)
-        full = super(date, year: year)
+        full = super(date, year:)
         if full[0..1] == '1 '
           "1º#{full[1..]}"
         else

--- a/lib/r18n-core/translation.rb
+++ b/lib/r18n-core/translation.rb
@@ -88,10 +88,10 @@ module R18n
           when Hash
             value = Translation.new(
               @locale, path,
-              locale: locale, translations: value, filters: @filters
+              locale:, translations: value, filters: @filters
             )
           when String
-            c = { locale: locale, path: path }
+            c = { locale:, path: }
             v = @filters.process_string(:passive, value, c, [])
             value = TranslatedString.new(v, locale, path, @filters)
           when Typed

--- a/lib/r18n-core/unsupported_locale.rb
+++ b/lib/r18n-core/unsupported_locale.rb
@@ -61,10 +61,10 @@ module R18n
       @base.public_send(name, *params)
     end
 
-    def respond_to_missing?(name, *args)
+    def respond_to_missing?(name, *)
       return super unless @base
 
-      @base.send __method__, name, *args
+      @base.send __method__, name, *
     end
   end
 end

--- a/r18n-core.gemspec
+++ b/r18n-core.gemspec
@@ -35,5 +35,5 @@ Gem::Specification.new do |s|
     'source_code_uri' => github_uri
   }
 
-  s.required_ruby_version = '>= 3.0', '< 4'
+  s.required_ruby_version = '>= 3.2', '< 4'
 end

--- a/spec/locale_spec.rb
+++ b/spec/locale_spec.rb
@@ -93,15 +93,15 @@ describe R18n::Locale do
   it 'localizes date for human' do
     i18n = R18n::I18n.new('en')
 
-    expect(@en.localize(Date.today + 2, :human, i18n: i18n)).to eq('after 2 days')
-    expect(@en.localize(Date.today + 1, :human, i18n: i18n)).to eq('tomorrow')
-    expect(@en.localize(Date.today,     :human, i18n: i18n)).to eq('today')
-    expect(@en.localize(Date.today - 1, :human, i18n: i18n)).to eq('yesterday')
-    expect(@en.localize(Date.today - 3, :human, i18n: i18n)).to eq('3 days ago')
+    expect(@en.localize(Date.today + 2, :human, i18n:)).to eq('after 2 days')
+    expect(@en.localize(Date.today + 1, :human, i18n:)).to eq('tomorrow')
+    expect(@en.localize(Date.today,     :human, i18n:)).to eq('today')
+    expect(@en.localize(Date.today - 1, :human, i18n:)).to eq('yesterday')
+    expect(@en.localize(Date.today - 3, :human, i18n:)).to eq('3 days ago')
 
     y2k = Date.parse('2000-05-08')
-    expect(@en.localize(y2k, :human, now: y2k + 8, i18n: i18n)).to   eq('8th of May')
-    expect(@en.localize(y2k, :human, now: y2k - 365, i18n: i18n)).to eq('8th of May, 2000')
+    expect(@en.localize(y2k, :human, now: y2k + 8, i18n:)).to   eq('8th of May')
+    expect(@en.localize(y2k, :human, now: y2k - 365, i18n:)).to eq('8th of May, 2000')
   end
 
   it 'localizes times for human' do


### PR DESCRIPTION
I've got the warning:

```
Bundle updated!
Post-install message from i18n:
PSA: I18n will be dropping support for Ruby < 3.2 in the next major release (April 2025), due to Ruby's end of life for 3.1 and below (https://endoflife.date/ruby). Please upgrade to Ruby 3.2 or newer by April 2025 to continue using future versions of this gem.
```