### PR TITLE
Fix bug with caching in variables filter (with specs)

### DIFF
--- a/lib/r18n-core/filters.rb
+++ b/lib/r18n-core/filters.rb
@@ -242,14 +242,15 @@ module R18n
   Filters.add(String, :variables) do |content, config, *params|
     cached_params = {}
     content.to_s.gsub(/%(\d)/) do
-      i = ::Regexp.last_match(1).to_i
-      unless cached_params.key?(i - 1)
-        param = config[:locale].localize(params[i - 1])
+      ## In translation files we start with `%1`, in code we start with index `0`
+      i = ::Regexp.last_match(1).to_i - 1
+      unless cached_params.key?(i)
+        param = config[:locale].localize(params[i])
         param = ActiveSupport::SafeBuffer.new + param if defined? ActiveSupport::SafeBuffer
 
-        cached_params[i - 1] = param
+        cached_params[i] = param
       end
-      cached_params[i - 1]
+      cached_params[i]
     end
   end
 

--- a/lib/r18n-core/filters.rb
+++ b/lib/r18n-core/filters.rb
@@ -240,10 +240,10 @@ module R18n
   end
 
   Filters.add(String, :variables) do |content, config, *params|
-    cached_params = []
+    cached_params = {}
     content.to_s.gsub(/%\d/) do |key|
       i = key[1..].to_i
-      unless cached_params.include? i - 1
+      unless cached_params.key?(i - 1)
         param = config[:locale].localize(params[i - 1])
         param = ActiveSupport::SafeBuffer.new + param if defined? ActiveSupport::SafeBuffer
 

--- a/lib/r18n-core/filters.rb
+++ b/lib/r18n-core/filters.rb
@@ -241,15 +241,18 @@ module R18n
 
   Filters.add(String, :variables) do |content, config, *params|
     cached_params = {}
+
     content.to_s.gsub(/%(\d)/) do
       ## In translation files we start with `%1`, in code we start with index `0`
       i = ::Regexp.last_match(1).to_i - 1
+
       unless cached_params.key?(i)
         param = config[:locale].localize(params[i])
         param = ActiveSupport::SafeBuffer.new + param if defined? ActiveSupport::SafeBuffer
 
         cached_params[i] = param
       end
+
       cached_params[i]
     end
   end

--- a/lib/r18n-core/filters.rb
+++ b/lib/r18n-core/filters.rb
@@ -242,7 +242,7 @@ module R18n
   Filters.add(String, :variables) do |content, config, *params|
     cached_params = {}
 
-    content.to_s.gsub(/%(\d)/) do
+    content.to_s.gsub(/%(\d+)/) do
       ## In translation files we start with `%1`, in code we start with index `0`
       i = ::Regexp.last_match(1).to_i - 1
 

--- a/lib/r18n-core/filters.rb
+++ b/lib/r18n-core/filters.rb
@@ -241,8 +241,8 @@ module R18n
 
   Filters.add(String, :variables) do |content, config, *params|
     cached_params = {}
-    content.to_s.gsub(/%\d/) do |key|
-      i = key[1..].to_i
+    content.to_s.gsub(/%(\d)/) do
+      i = ::Regexp.last_match(1).to_i
       unless cached_params.key?(i - 1)
         param = config[:locale].localize(params[i - 1])
         param = ActiveSupport::SafeBuffer.new + param if defined? ActiveSupport::SafeBuffer

--- a/spec/filters_spec.rb
+++ b/spec/filters_spec.rb
@@ -192,6 +192,15 @@ describe R18n::Filters do
     expect(i18n.params('0', '1')).to eq('Is 0 between 0 and 1?')
   end
 
+  it 'processes 2+ digits params in translation' do
+    expect(
+      i18n.a_lot_of_params(
+        'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten',
+        'eleven', 'twelve'
+      )
+    ).to eq('List: one, two, three, four, five, six, seven, eight, nine, ten, eleven, twelve!')
+  end
+
   it "substitutes '%2' as param but not value of second param" do
     expect(i18n.params('%2 FIRST', 'SECOND')).to eq(
       'Is %2 FIRST between %2 FIRST and SECOND?'

--- a/spec/filters_spec.rb
+++ b/spec/filters_spec.rb
@@ -192,6 +192,12 @@ describe R18n::Filters do
     expect(i18n.params('0', '1')).to eq('Is 0 between 0 and 1?')
   end
 
+  it 'caches `nil` params in translation' do
+    expect(i18n.locale).to receive(:localize).exactly(2).times.and_call_original
+
+    expect(i18n.params(nil, 'something')).to eq('Is  between  and something?')
+  end
+
   it 'processes 2+ digits params in translation' do
     expect(
       i18n.a_lot_of_params(

--- a/spec/filters_spec.rb
+++ b/spec/filters_spec.rb
@@ -33,6 +33,21 @@ describe R18n::Filters do
     expect(i18n.my_tree_filter).to eq('name' => 'value')
   end
 
+  it 'adds cached filter' do
+    filter = R18n::Filters.add('my', :params) { |i, _config| i }
+    expect(i18n.locale).to receive(:localize).exactly(2).times.and_call_original
+
+    expect(filter).to be_kind_of(R18n::Filters::Filter)
+    expect(filter.name).to eq(:params)
+    expect(filter.types).to eq(['my'])
+    expect(filter).to be_enabled
+
+    expect(R18n::Filters.defined).to have_key(:params)
+
+    expect(i18n.params('0', '1')).to eq('Is 0 between 0 and 1?')
+    expect(i18n.my_tree_filter).to eq('name' => 'value')
+  end
+
   it 'adds filter for several types' do
     R18n::Filters.add(%w[my your]) { |i, _config| "#{i}1" }
     expect(i18n.my_filter).to   eq('value1')

--- a/spec/filters_spec.rb
+++ b/spec/filters_spec.rb
@@ -33,21 +33,6 @@ describe R18n::Filters do
     expect(i18n.my_tree_filter).to eq('name' => 'value')
   end
 
-  it 'adds cached filter' do
-    filter = R18n::Filters.add('my', :params) { |i, _config| i }
-    expect(i18n.locale).to receive(:localize).exactly(2).times.and_call_original
-
-    expect(filter).to be_kind_of(R18n::Filters::Filter)
-    expect(filter.name).to eq(:params)
-    expect(filter.types).to eq(['my'])
-    expect(filter).to be_enabled
-
-    expect(R18n::Filters.defined).to have_key(:params)
-
-    expect(i18n.params('0', '1')).to eq('Is 0 between 0 and 1?')
-    expect(i18n.my_tree_filter).to eq('name' => 'value')
-  end
-
   it 'adds filter for several types' do
     R18n::Filters.add(%w[my your]) { |i, _config| "#{i}1" }
     expect(i18n.my_filter).to   eq('value1')
@@ -199,6 +184,12 @@ describe R18n::Filters do
 
   it 'cans use params in translation' do
     expect(i18n.params(-1, 2)).to eq('Is −1 between −1 and 2?')
+  end
+
+  it 'caches params in translation' do
+    expect(i18n.locale).to receive(:localize).exactly(2).times.and_call_original
+
+    expect(i18n.params('0', '1')).to eq('Is 0 between 0 and 1?')
   end
 
   it "substitutes '%2' as param but not value of second param" do

--- a/spec/translations/general/en.yml
+++ b/spec/translations/general/en.yml
@@ -2,6 +2,7 @@ one: One
 two: Two
 
 params: Is %1 between %1 and %2?
+a_lot_of_params: 'List: %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12!'
 
 in:
   another:


### PR DESCRIPTION
This PR attempts to finish the work from #106.

Please see my comment here: https://github.com/r18n/r18n-core/pull/106#issuecomment-2382594309

After formulating the problem, I came up with this possible solution. The spec counts whether duplicate keys are translated (the proper amount of times) or being loaded from the cache.

🚨 Current `main` branch runs thrice.